### PR TITLE
rules: Fix possible TypeError in best_hand

### DIFF
--- a/server/rules.py
+++ b/server/rules.py
@@ -454,7 +454,7 @@ def eval_waits(tiles, options={}):
 
 def best_hand(tiles, wait, options={}):
     hands = all_hands(tiles, wait, options=options)
-    return max((hand.fan(), hand.fu(), hand) for hand in hands)[2]
+    return max(((hand.fan(), hand.fu(), hand) for hand in hands), key=lambda k: (k[0], k[1]))[2]
 
 def eval_hand(tiles, wait, options={}):
     hand = best_hand(tiles, wait, options=options)
@@ -517,9 +517,7 @@ class RulesTestCase(unittest.TestCase):
     def test_best_hand_sort(self):
         tiles = 'M7 M7 M8 M8 M9 M9 S1 S2 S3 X1 X1 X3 X3 X3'.split()
         wait  = 'M7'
-        print(tiles)
-        hand = best_hand(tiles, wait, {'fanpai_winds': ['X1'], 'dora_ind': 'X4'})
-        print(hand)
+        best_hand(tiles, wait, {'fanpai_winds': ['X1'], 'dora_ind': 'X4'})
 
 class BaseHandTestCase(unittest.TestCase):
     def assertYaku(self, tiles_str, wait, yaku_sets):

--- a/server/rules.py
+++ b/server/rules.py
@@ -514,6 +514,13 @@ class RulesTestCase(unittest.TestCase):
         self.assertEquals(dora_for_ind('X6'), 'X7')
         self.assertEquals(dora_for_ind('X7'), 'X5')
 
+    def test_best_hand_sort(self):
+        tiles = 'M7 M7 M8 M8 M9 M9 S1 S2 S3 X1 X1 X3 X3 X3'.split()
+        wait  = 'M7'
+        print(tiles)
+        hand = best_hand(tiles, wait, {'fanpai_winds': ['X1'], 'dora_ind': 'X4'})
+        print(hand)
+
 class BaseHandTestCase(unittest.TestCase):
     def assertYaku(self, tiles_str, wait, yaku_sets):
         tiles = tiles_str.split()


### PR DESCRIPTION
Also adds a test case for the case where I encountered this issue

Traceback as printed when I first encountered the error:
```
Traceback (most recent call last):
  File "/home/minefield/minefield/server/room.py", line 68, in send_to_game
    handler(idx, msg)
  File "/home/minefield/minefield/server/game.py", line 206, in on_discard
    if self.check_ron(player, tile):
  File "/home/minefield/minefield/server/game.py", line 220, in check_ron
    hand = rules.best_hand(full_hand, tile, options=self.options(1-player))
  File "/home/minefield/minefield/server/rules.py", line 457, in best_hand
    return max((hand.fan(), hand.fu(), hand) for hand in hands)[2]
TypeError: '>' not supported between instances of 'Hand' and 'Hand'
```